### PR TITLE
Make the buffer temporary and exitable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "contextpilot",
     "displayName": "Context Pilot",
     "description": "Get the context right at your editor with a single command",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "publisher": "tgkrs",
     "engines": {
         "vscode": "^1.79.0"
@@ -38,7 +38,7 @@
             },
             {
                 "command": "contextpilot.indexSubdirectories",
-                "title": "ContextPilot: Index All Subdirectories"
+                "title": "ContextPilot: Index Subdirectories"
             }
         ]
     },
@@ -55,7 +55,6 @@
     },
     "devDependencies": {
         "@types/glob": "^8.1.0",
-        "@types/mocha": "^10.0.1",
         "@types/node": "20.2.5",
         "@types/vscode": "^1.79.0",
         "@typescript-eslint/eslint-plugin": "^5.59.8",


### PR DESCRIPTION
Before this, when you hit enter on the "Get Relevant Commits" output - it will open the buffer, but closing it will prompt you to whether save or not. This fixes the same, no more prompts now.