### PR TITLE
Fix indexing to be cancellable and don't preserve focus for output logs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,37 +108,6 @@ class CommitDescriptionProvider implements vscode.TextDocumentContentProvider {
 const commitDescriptionProvider = new CommitDescriptionProvider();
 vscode.workspace.registerTextDocumentContentProvider("commitdesc", commitDescriptionProvider);
 
-class LLMAnalysisProvider implements vscode.TextDocumentContentProvider {
-    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-    onDidChange = this._onDidChange.event;
-    private contentMap = new Map<string, string>();
-    private chatHistory: { role: string; content: string }[] = [];
-
-    provideTextDocumentContent(uri: vscode.Uri): string {
-        return this.contentMap.get(uri.toString()) || "";
-    }
-
-    setContent(uri: vscode.Uri, content: string) {
-        this.contentMap.set(uri.toString(), content);
-        this._onDidChange.fire(uri);
-    }
-
-    addToChatHistory(role: string, content: string) {
-        this.chatHistory.push({ role, content });
-    }
-
-    getChatHistory() {
-        return this.chatHistory;
-    }
-
-    clearChatHistory() {
-        this.chatHistory = [];
-    }
-}
-
-const llmAnalysisProvider = new LLMAnalysisProvider();
-vscode.workspace.registerTextDocumentContentProvider("llmanalysis", llmAnalysisProvider);
-
 async function runCommand(commandType: string, type: string) {
     if (!(await checkContextPilotVersion())) return;
 
@@ -273,7 +242,7 @@ const indexWorkspaceCommand = vscode.commands.registerCommand(
 
         const command = `contextpilot ${workspacePath} -t index`;
         const outputChannel = vscode.window.createOutputChannel("ContextPilot Logs");
-        outputChannel.show(true);
+        outputChannel.show(false);
 
         vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,7 +278,7 @@ const indexWorkspaceCommand = vscode.commands.registerCommand(
         vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
             title: "ContextPilot: Indexing Workspace",
-            cancellable: false
+            cancellable: true
         }, async () => {
             return new Promise((resolve, reject) => {
                 const cp = childProcess.exec(command, { cwd: workspacePath }, (error, stdout, stderr) => {


### PR DESCRIPTION
This pull request introduces the ability to cancel the workspace indexing process. This enhancement improves user experience by allowing users to stop indexing operations when no longer needed or if initiated by mistake. 

Post this commit, output channel won't preserve focus as well.